### PR TITLE
Change header

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ url: 'https://wott.io'
 
 # Website info
 title: Web of Trusted Things
-description: Seamless security audit of linux systems for devops teams.
+description: Seamless security audit of linux systems for DevOps teams.
 cover: assets/images/blog-cover.jpg
 favicon: assets/images/favicon.png
 

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ url: 'https://wott.io'
 
 # Website info
 title: Web of Trusted Things
-description: WoTT is an automated, open-source public key infrastructure for connected hardware
+description: Seamless security audit of linux systems for devops teams.
 cover: assets/images/blog-cover.jpg
 favicon: assets/images/favicon.png
 


### PR DESCRIPTION
It changes website header from "WoTT is an automated, open-source public key infrastructure for connected hardware." to "Seamless security audit of linux systems for devops teams."

Issue: https://github.com/WoTTsecurity/wott-io/issues/170